### PR TITLE
Add example file and fix README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Markdown files, ensuring your code examples are always up-to-date.
 2.  **In your Markdown file**, you reference that snippet using an HTML
     comment:
 
-    ````markdown
-    <!-- snips: examples/example.rs#main_feature -->
-    ```rust
-    println!("This is the code I want in my docs!");
-    ```
-    ````
+````markdown
+<!-- snips: examples/example.rs#main_feature -->
+```rust
+println!("This is the code I want in my docs!");
+```
+````
 
 Run `snips process`, and the tool will inject the source code, automatically
 handling indentation and language detection.

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,0 +1,9 @@
+pub fn example() {
+    // snips-start: main_feature
+    println!("This is the code I want in my docs!");
+    // snips-end: main_feature
+}
+
+fn main() {
+    example();
+}


### PR DESCRIPTION
## Summary
- add `examples/example.rs` demonstrating snippet markers
- update README snippet to have the marker at the start of the line so `snips` can process it
- show how to call the example from `main`

## Testing
- `cargo test --quiet`
- `cargo run --quiet -- render README.md`

------
https://chatgpt.com/codex/tasks/task_e_68830836aa088333a3c02edc1a2a596f