### PR TITLE
Remove verbose CLI flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,6 @@ use std::path::PathBuf;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
-    /// Enable verbose logging
-    #[arg(short, long, action = clap::ArgAction::Count)]
-    verbose: u8,
     /// Quiet mode
     #[arg(long, action = clap::ArgAction::SetTrue)]
     quiet: bool,


### PR DESCRIPTION
## Summary
- delete unused verbose argument from CLI

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688363c6fdf08333a362503256ae058f